### PR TITLE
fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ A collection of awesome resources about OpenComponents (aka OC). Please read the
 ## Components examples
 * [Components examples](https://github.com/matteofigus/oc-components-examples) - OC Components examples
 * [Testing OC components](https://github.com/opentable/oc-testing) - Code examples for unit/acceptance/ui testing components
-* [OC With React](https://github.com/mattiaerre/oc-with-react) - OC + React component example
-* [OC feedback form](https://github.com/mattiaerre/oc-feedback-form) - An OC component example that shows how to implement HTTP POST
+* [Open Components Hub](https://github.com/mattiaerre/oc-hub) SSR, React, how to HTTP POST and many more spikes and examples w/ OpenComponents
 
 ## Tools for writing/debugging components
 * [Oh See](https://github.com/opentable/oh-see) - Testing tool for visually testing OC components in production before publishing


### PR DESCRIPTION
# Description

- `oc-with-react` and `oc-feedback-form` have been moved under `oc-hub`; hence the broken links